### PR TITLE
Fixed. "bundle" from bundler conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,4 @@ ENV PATH /usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH
 
 RUN eval "$(rbenv init -)"; rbenv install 2.4.3 \
 &&  eval "$(rbenv init -)"; rbenv global 2.4.3 \
-&&  eval "$(rbenv init -)"; gem update --system \
-&&  eval "$(rbenv init -)"; gem install bundler
+&&  eval "$(rbenv init -)"; gem update --system


### PR DESCRIPTION
```
Step 10/10 : RUN eval "$(rbenv init -)"; rbenv install 2.4.3 &&  eval "$(rbenv init -)"; rbenv global 2.4.3 &&  eval "$(rbenv init -)"; gem update --system &&  eval "$(rbenv init -)"; gem install bundler

 ---> Running in 006ebf25479a

[91mDownloading ruby-2.4.3.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2
[0m
[91mInstalling ruby-2.4.3...
[0m
[91mInstalled ruby-2.4.3 to /usr/local/rbenv/versions/2.4.3

[0m
Updating rubygems-update

Successfully installed rubygems-update-2.7.3
Parsing documentation for rubygems-update-2.7.3
Installing ri documentation for rubygems-update-2.7.3
Installing darkfish documentation for rubygems-update-2.7.3
Done installing documentation for rubygems-update after 92 seconds
Parsing documentation for rubygems-update-2.7.3
Done installing documentation for rubygems-update after 0 seconds
Installing RubyGems 2.7.3

Bundler 1.16.0 installed
RubyGems 2.7.3 installed
Regenerating binstubs

RubyGems system software updated

[91mERROR:  Error installing bundler:
  "bundle" from bundler conflicts with /usr/local/rbenv/versions/2.4.3/bin/bundle
[0m
Removing intermediate container 006ebf25479a

The command '/bin/sh -c eval "$(rbenv init -)"; rbenv install 2.4.3 &&  eval "$(rbenv init -)"; rbenv global 2.4.3 &&  eval "$(rbenv init -)"; gem update --system &&  eval "$(rbenv init -)"; gem install bundler' returned a non-zero code: 1
```