### PR TITLE
Install 2.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUBY_PATH=/usr/local
-ARG RUBY_VERSION=2.6.1
+ARG RUBY_VERSION=2.6.2
 
 FROM drecom/centos-base:7 AS rubybuild
 ARG RUBY_PATH


### PR DESCRIPTION
https://www.ruby-lang.org/ja/news/2019/03/13/ruby-2-6-2-released/